### PR TITLE
Resolve deprecation warning regarding the use of plist_option

### DIFF
--- a/Formula/opensearch@1.rb
+++ b/Formula/opensearch@1.rb
@@ -79,7 +79,6 @@ class OpensearchAT1 < Formula
     EOS
   end
 
-  plist_options manual: "opensearch"
   service do
     run opt_bin/"opensearch"
     working_dir var


### PR DESCRIPTION
This resolves the following warning:

    Warning: Calling plist_options is deprecated! Use service.require_root instead.