### PR TITLE
Use macos-11 runner image in GitHub tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-10.15]
+        os: [ubuntu-22.04, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
This is possible since the release of OpenSearch 1.3.9.

See also #1.